### PR TITLE
Fix data submission

### DIFF
--- a/src/hbb/processors/categorizer.py
+++ b/src/hbb/processors/categorizer.py
@@ -356,6 +356,8 @@ class categorizer(SkimmerABC):
         else:
             systematics = [shift_name]
 
+        nominal_weight = ak.ones_like(candidatejet.pt) if isRealData else weights.weight()
+
         output_array = None
         if self._save_skim:
             # define "flat" output array
@@ -366,7 +368,7 @@ class categorizer(SkimmerABC):
                     "FatJet_msdcorr": candidatejet.msdcorr,
                     "FatJet_btag": bvl,
                     "mjj": mjj,
-                    "weight": weights.weight(),
+                    "weight": nominal_weight,
                     **gen_variables,
                 },
                 depth_limit=1,
@@ -376,13 +378,14 @@ class categorizer(SkimmerABC):
             selections = regions[region]
             cut = selection.all(*selections)
             sname = "nominal" if systematic is None else systematic
+
             if wmod is None:
-                if systematic in weights.variations:
+                if systematic in weights.variations and not isRealData:
                     weight = weights.weight(modifier=systematic)[cut]
                 else:
-                    weight = weights.weight()[cut]
+                    weight = nominal_weight[cut]
             else:
-                weight = weights.weight()[cut] * wmod[cut]
+                weight = nominal_weight[cut] * wmod[cut]
 
             output["templates"].fill(
                 dataset=dataset,
@@ -411,6 +414,7 @@ class categorizer(SkimmerABC):
                 skim_path.mkdir(parents=True, exist_ok=True)
             print("Saving skim to: ", skim_path)
 
+            # possible TODO: add systematic weights?
             output["skim"][region] = dak.to_parquet(
                 output_array[cut],
                 str(skim_path),


### PR DESCRIPTION
Weights were None and was getting this error

```
(hbb) bash-5.1$ python -u -W ignore src/run.py --year 2022EE --starti 0 --endi 1 --samples JetMET --subsamples JetMET_Run2022E --nano-version v12 --save-skim
Namespace(year='2022EE', starti=0, endi=1, samples=['JetMET'], subsamples=['JetMET_Run2022E'], nano_version='v12', files=[], files_name='files', yaml=None, save_skim=True)
Running on fileset {'2022EE_JetMET_Run2022E': ['root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2022E/JetMET/NANOAOD/22Sep2023-v1/30000/002cde4c-efa1-430d-b651-61b6dff4d208.root']}
Number of files preprocessed:  1  out of  1
Saving skim to:  outparquet/2022EE/2022EE_JetMET_Run2022E/signal-all
Traceback (most recent call last):
  File "/uscms_data/d3/cmantill/hbb/hbb-run3/src/run.py", line 232, in <module>
    main(args)
  File "/uscms_data/d3/cmantill/hbb/hbb-run3/src/run.py", line 175, in main
    run(args.year, fileset, args)
  File "/uscms_data/d3/cmantill/hbb/hbb-run3/src/run.py", line 94, in run
    full_tg, rep = apply_to_fileset(
  File "/uscms_data/d3/cmantill/micromamba/envs/hbb/lib/python3.10/site-packages/coffea/dataset_tools/apply_processor.py", line 127, in apply_to_fileset
    dataset_out = apply_to_dataset(
  File "/uscms_data/d3/cmantill/micromamba/envs/hbb/lib/python3.10/site-packages/coffea/dataset_tools/apply_processor.py", line 82, in apply_to_dataset
    out = data_manipulation.process(events)
  File "/uscms_data/d3/cmantill/hbb/hbb-run3/src/hbb/processors/categorizer.py", line 115, in process
    return self.process_shift(events, None)
  File "/uscms_data/d3/cmantill/hbb/hbb-run3/src/hbb/processors/categorizer.py", line 431, in process_shift
    fill(region, systematic)
  File "/uscms_data/d3/cmantill/hbb/hbb-run3/src/hbb/processors/categorizer.py", line 388, in fill
    weight = weights.weight()[cut]
TypeError: 'NoneType' object is not subscriptable
````