### PR TITLE
correct year mapping in 2024 photon ID

### DIFF
--- a/src/hbb/corrections.py
+++ b/src/hbb/corrections.py
@@ -506,7 +506,7 @@ def add_photon_weights(weights: Weights, year: str, photons, alt_str: str):
         "2022EE" : "2022Re-recoE+PromptFG",
         "2023" : "2023PromptC",
         "2023BPix" : "2023PromptD",
-        "2024" : "2024",
+        "2024" : "2024_ID",
     }
 
     if not year == "2024":


### PR DESCRIPTION
Current photon ID file for 2024 is: `/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/EGM/2024_Summer24/photonID_v1.json.gz`

It only has a single year key, `2024_ID`.
```json
...
"data": {
    "nodetype": "category",
    "input": "year",
    "content": [
        {
            "key": "2024_ID",
            "value": {
                "nodetype": "category",
                "input": "ValType",
...
```