### PR TITLE
JMSR calibration infrastructure for Z+γ control region

### DIFF
--- a/fitting/README.md
+++ b/fitting/README.md
@@ -83,6 +83,11 @@ python make_datacards.py \
     --analysis zgcr
 ```
 
+When including JMS/R, can use:
+```
+python plot_jmsr.py --file results/26Feb03/2022EE/datacards/zgcrModel_2022EE/zgcrModel_2022EE.root
+```
+
 ### For the signal region:
 ```
 python make_datacards.py \
@@ -213,3 +218,10 @@ python3 make_plots.py \
 - `--onto`: Specifies a background (usually QCD) to plot as an unfilled line, stacking other processes on top of it.
 
 - `-p`: Enables multiprocessing to speed up the rendering of multiple categories simultaneously.
+
+### 8.4 JMSR Validation
+
+To plot and get the final fit results use `plot_jmsr_postfit.py`:
+```
+ python plot_jmsr_postfit.py --fitfile results/.../fitDiagnosticsTest.root --wsfile  results/.../zgcrModel_2022EE.root --year 2022EE -j setup_zgcr.json
+```

--- a/fitting/card_utils.py
+++ b/fitting/card_utils.py
@@ -8,6 +8,7 @@ Date: Feb 2026
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -200,9 +201,7 @@ def plot_mctf(tf_MCtempl, msdbins, name, _year, _tag, out_dir_base, pt_min=450.0
     print(f"Saved MCTF plots to {outdir}")
 
 
-def add_systematics(
-    sample, nominal, systs, infile_path, _year, components, region, ptbin, cat, obs
-):
+def add_systematics(sample, nominal, systs, infile_path, components, region, ptbin, cat, obs):
     """
     Applies lnN and Shape systematics to a Rhalphalib sample object.
 
@@ -211,7 +210,6 @@ def add_systematics(
         nominal (np.array): The nominal yield array.
         systs (dict): Dictionary mapping sys_name -> rl.NuisanceParameter.
         infile_path (Path): Path to ROOT file.
-        year (str): Analysis year.
         components (list): List of (process, flavor) tuples for merging.
         region (str): Region string (e.g. 'pass_bb_').
         ptbin (int): Bin index.
@@ -234,8 +232,36 @@ def add_systematics(
         syst_down = get_merged_template(
             infile_path, components, region, ptbin, cat, obs, syst=sys_name + "Down"
         )[0]
-        # Convert shape variation to single normalization number (lnN effect)
-        eff_up = shape_to_num(syst_up, nominal)
-        eff_do = shape_to_num(syst_down, nominal)
 
-        sample.setParamEffect(nuisance_par, eff_up, eff_do)
+        if nuisance_par.combinePrior == "lnN":
+            # Convert shape variation to single normalization number (lnN effect)
+            eff_up = shape_to_num(syst_up, nominal)
+            eff_do = shape_to_num(syst_down, nominal)
+
+            # In rhalphalib, eff_up is a numpy array representing the relative (multiplicative)
+            # effect of the parameter on the bin yields
+            sample.setParamEffect(nuisance_par, eff_up, eff_do)
+
+        elif nuisance_par.combinePrior == "shape":
+            # for shape priors rhalphalib expects a multiplicative per-bin array
+            sample.setParamEffect(
+                nuisance_par,
+                safe_ratio(syst_up, nominal),
+                safe_ratio(syst_down, nominal),
+            )
+
+        else:
+            warnings.warn(
+                f"Systematic {nuisance_par.name!r} has prior "
+                f"{nuisance_par.combinePrior!r} which is not yet implemented — skipping.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+
+# Guard against empty morphed templates
+def safe_ratio(varied, nom):
+    """Per-bin ratio clipped to [0.01, 100] when taking the ration between varied/nom template"""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(nom > 0, varied / nom, 1.0)
+    return np.clip(ratio, 0.01, 100.0)

--- a/fitting/make_datacards.py
+++ b/fitting/make_datacards.py
@@ -22,9 +22,11 @@ from card_utils import (
     badtemplate,
     get_merged_template,
     get_template,
+    one_bin,
     plot_mctf,
-    one_bin
+    safe_ratio,
 )
+from scalesmear import MorphHistW2
 
 from hbb.common_vars import LUMI
 
@@ -33,7 +35,7 @@ warnings.filterwarnings("ignore")
 rl.util.install_roofit_helpers()
 
 lumi_err = {"2022": 1.01, "2023": 1.02, "2024": 1.02}  # 2024: TODO get official CMS value
-eps = 0.001 
+eps = 0.001
 
 
 def rhalphabet(args):
@@ -67,7 +69,7 @@ def rhalphabet(args):
     # Files & naming
     root_file_name = config.get("root_filename", "signalregion.root").replace("{year}", year)
 
-    # [FIXED] Define infile_path here!
+    # Define infile_path here!
     infile_path = Path(args.indir) / root_file_name if args.indir else working_dir / root_file_name
 
     qcd_tf_proc = config.get("qcd_proc", "QCD")
@@ -80,6 +82,13 @@ def rhalphabet(args):
     for group in sample_dict.values():
         group["components"] = [tuple(c) for c in group["components"]]
 
+    # Jet Mass Scale and Resolution
+    # shift the mass axis up/down by JMSR_SCALE GeV,
+    JMSR_SCALE = config.get("jmsr_scale", 1.0)  # read from JSON or hardcode
+    # broaden/narrow the distribution by JMSR_SMEAR fraction
+    JMSR_SMEAR = config.get("jmsr_smear", 0.1)  # read from JSON or hardcode
+    jmsr_processes = config.get("jmsr_processes", [])  # e.g. ["zgammabb"] in JSON
+
     # ---------------------------------------------------------
     # 3. OBSERVABLES & SYSTEMATICS
     # ---------------------------------------------------------
@@ -90,12 +99,12 @@ def rhalphabet(args):
     cats_cfg = config["categories"]
     cats = list(cats_cfg.keys())
     if "mucr" in cats:
-        cats.remove("mucr") #necessary since all categories get the same treatment
+        cats.remove("mucr")  # necessary since all categories get the same treatment
 
     # TT Independent Parameters
-    tqqeffSF = rl.IndependentParameter(f'tqqeffSF_{year}', 1., -50, 50)
-    tqqeffBCSF = rl.IndependentParameter(f'tqqeffBCSF_{year}', 1., -50, 50)
-    tqqnormSF = rl.IndependentParameter(f'tqqnormSF_{year}', 1., -50, 50)
+    tqqeffSF = rl.IndependentParameter(f"tqqeffSF_{year}", 1.0, -50, 50)
+    tqqeffBCSF = rl.IndependentParameter(f"tqqeffBCSF_{year}", 1.0, -50, 50)
+    tqqnormSF = rl.IndependentParameter(f"tqqnormSF_{year}", 1.0, -50, 50)
 
     do_muon_CR = config.get("do_muon_CR", False)
 
@@ -122,6 +131,10 @@ def rhalphabet(args):
             "btagSFlight_correlated": rl.NuisanceParameter(
                 f"CMS_btagSFlight_correlated_{year}", "lnN"
             ),
+            "JMSunconstrained": rl.NuisanceParameter(f"CMS_jms_{year}", "shapeU", lo=-5, hi=5),
+            "JMRunconstrained": rl.NuisanceParameter(f"CMS_jmr_{year}", "shapeU", lo=-5, hi=5),
+            "JMS": rl.NuisanceParameter(f"CMS_jms_{year}", "shape"),
+            "JMR": rl.NuisanceParameter(f"CMS_jmr_{year}", "shape"),
         }
 
         # --- B. Theory Systematics (PDF, Scale, ISR/FSR) ---
@@ -290,6 +303,12 @@ def rhalphabet(args):
 
                 if qcdfit.status() != 0:
                     fitfailed_qcd[reg] += 1
+                    print(f"  [FIT] Attempt {fitfailed_qcd[reg]}/5 failed for {cat} {reg}"
+                          f" — status={qcdfit.status()}, covQual={qcdfit.covQual()}")
+                    # Perturb initial values randomly for next attempt
+                    perturbed = np.random.uniform(0.5, 2.0, tf_MCtempl.parameters.shape)
+                    for p, v in zip(tf_MCtempl.parameters.reshape(-1), perturbed.reshape(-1)):
+                        p.value = v
                 else:
                     allparams = dict(zip(qcdfit.nameArray(), qcdfit.valueArray()))
                     pvalues = [allparams[p.name] for p in tf_MCtempl.parameters.reshape(-1)]
@@ -299,6 +318,11 @@ def rhalphabet(args):
                     break
 
             if fitfailed_qcd[reg] >= 5:
+                print(f"\n[FIT] All 5 attempts failed for {cat} {reg}.")
+                print(f"  Last status={qcdfit.status()}, covQual={qcdfit.covQual()}")
+                print(f"  covQual meanings: -1=not calc, 0=not pos-def, 1=forced pos-def, 2=approx, 3=full accurate")
+                print(f"  MC template order: pt={args.mc_pt_order}, rho={args.mc_rho_order}")
+                print(f"  Inclusive P/F = {qcdeff:.4f} — if very small, model may be overparameterized")
                 raise RuntimeError(f"Could not fit QCD for {cat} {reg} after 5 tries!")
 
             plot_mctf(
@@ -360,6 +384,7 @@ def rhalphabet(args):
 
                 for proc_name, info in sample_dict.items():
                     # proc_name is e.g., 'ggF', 'VBF', 'ttbar'
+                    # this is a (sumw, edges, name, sumw2) tuple
                     templ = get_merged_template(
                         infile_path, info["components"], region, binindex + 1, cat, msd
                     )
@@ -374,7 +399,7 @@ def rhalphabet(args):
                     stype = rl.Sample.SIGNAL if info["is_signal"] else rl.Sample.BACKGROUND
                     sample = rl.TemplateSample(ch.name + "_" + proc_name, stype, templ)
 
-                    # Apply Luminosity
+                    # Apply Luminosity Uncertainty
                     sample.setParamEffect(
                         sys_lumi_uncor, lumi_err[year[:4]] ** (LUMI[year[:4]] / LUMI["2022-2024"])
                     )
@@ -384,11 +409,11 @@ def rhalphabet(args):
                         # (Already handled inside add_systematics in card_utils.py)
 
                         # 2. Experimental Systematics (Shapes from ROOT file)
-                        # Filter out theory systematics so they aren't double-applied
+                        # Filter out specific systematics so they aren't double-applied
                         exp_syst_map = {
                             k: v
                             for k, v in syst_map.items()
-                            if not k.startswith(("pdf_", "scale_", "isr_", "fsr_"))
+                            if not k.startswith(("pdf_", "scale_", "isr_", "fsr_", "JMS", "JMR"))
                         }
 
                         add_systematics(
@@ -396,13 +421,69 @@ def rhalphabet(args):
                             nominal,
                             exp_syst_map,
                             infile_path,
-                            year,
                             info["components"],
                             region,
                             binindex + 1,
                             cat,
                             msd,
                         )
+
+                        # JMS/R systematics
+                        jmsr_syst_map = {
+                            k: v for k, v in syst_map.items() if k.startswith(("JMS", "JMR"))
+                        }
+
+                        if proc_name in jmsr_processes:
+                            # Build a MorphHistW2 from the already-loaded nominal template.
+                            sumw, edges, _name, sumw2 = templ
+                            morph = MorphHistW2((sumw, edges, sumw2))
+
+                            # Morphed Nominal
+                            morphed_nom, _, _ = morph.get(shift=0.0, scale=1.0)
+
+                            # Each pair shares the same morph — only one variant should be active at a time.
+                            jmsr_pairs = [
+                                (
+                                    "JMS",
+                                    "JMSunconstrained",
+                                    morph.get(shift=+JMSR_SCALE),
+                                    morph.get(shift=-JMSR_SCALE),
+                                ),
+                                (
+                                    "JMR",
+                                    "JMRunconstrained",
+                                    morph.get(scale=1.0 + JMSR_SMEAR),
+                                    morph.get(scale=1.0 - JMSR_SMEAR),
+                                ),
+                            ]
+
+                            for key_a, key_b, (up_vals, _, _), (dn_vals, _, _) in jmsr_pairs:
+                                active_key = next(
+                                    (k for k in (key_a, key_b) if k in jmsr_syst_map), None
+                                )
+                                if active_key is None:
+                                    continue
+                                print(
+                                    f"Adding {jmsr_syst_map[active_key].name} to {proc_name}, {region}"
+                                )
+
+                                if not np.allclose(morphed_nom, nominal, rtol=1e-3, atol=1e-6):
+                                    print(
+                                        f"  Warning: MorphHistW2 nominal mismatch for {proc_name} in {ch_name}. "
+                                        f"Max relative diff: {np.max(np.abs(morphed_nom - nominal) / np.maximum(nominal, 1e-10)):.4f}"
+                                    )
+
+                                sample.setParamEffect(
+                                    jmsr_syst_map[active_key],
+                                    safe_ratio(
+                                        up_vals, morphed_nom
+                                    ),  # take the ratio between up and nominal
+                                    safe_ratio(dn_vals, morphed_nom),
+                                    scale=1,  # this is a rescaling effect,
+                                    # most useful for shape effects where the nuisance parameter effect
+                                    # needs to be magnified to ensure good vertical interpolation
+                                    # it is better left at 1, to avoid confusion later
+                                )
 
                         # 3. Theory Systematics (Process-Specific Logic)
 
@@ -550,22 +631,25 @@ def rhalphabet(args):
             if do_muon_CR:
                 passChbb = model[f"ptbin{ptbin}{cat}passbb{year}"]
                 passChcc = model[f"ptbin{ptbin}{cat}passcc{year}"]
-                
-                tqqpassbb = passChbb['ttbar']
-                tqqpasscc = passChcc['ttbar']
-                tqqfail = failCh['ttbar']
 
-                sumPass = tqqpassbb.getExpectation(nominal=True).sum() + tqqpasscc.getExpectation(nominal=True).sum()
+                tqqpassbb = passChbb["ttbar"]
+                tqqpasscc = passChcc["ttbar"]
+                tqqfail = failCh["ttbar"]
+
+                sumPass = (
+                    tqqpassbb.getExpectation(nominal=True).sum()
+                    + tqqpasscc.getExpectation(nominal=True).sum()
+                )
                 sumFail = tqqfail.getExpectation(nominal=True).sum()
 
                 sumPassbb = tqqpassbb.getExpectation(nominal=True).sum()
                 sumPasscc = tqqpasscc.getExpectation(nominal=True).sum()
 
-                if 'singlet' in passCh.samples:
-                    stqqpassbb = passChbb['singlet']
-                    stqqpasscc = passChcc['singlet']
-                    stqqfail = failCh['singlet']
-                    
+                if "singlet" in passCh.samples:
+                    stqqpassbb = passChbb["singlet"]
+                    stqqpasscc = passChcc["singlet"]
+                    stqqfail = failCh["singlet"]
+
                     sumPass += stqqpassbb.getExpectation(nominal=True).sum()
                     sumPass += stqqpasscc.getExpectation(nominal=True).sum()
 
@@ -573,10 +657,10 @@ def rhalphabet(args):
                     sumPasscc += stqqpasscc.getExpectation(nominal=True).sum()
 
                     sumFail += stqqfail.getExpectation(nominal=True).sum()
-                    
-                    tqqPF =  sumPass / sumFail
+
+                    tqqPF = sumPass / sumFail
                     tqqBC = sumPassbb / sumPasscc
-                    
+
                     stqqpassbb.setParamEffect(tqqeffSF, 1 * tqqeffSF)
                     stqqpasscc.setParamEffect(tqqeffSF, 1 * tqqeffSF)
                     stqqfail.setParamEffect(tqqeffSF, (1 - tqqeffSF) * tqqPF + 1)
@@ -588,8 +672,7 @@ def rhalphabet(args):
                     stqqpasscc.setParamEffect(tqqnormSF, 1 * tqqnormSF)
                     stqqfail.setParamEffect(tqqnormSF, 1 * tqqnormSF)
 
-
-                tqqPF =  sumPass / sumFail
+                tqqPF = sumPass / sumFail
                 tqqBC = sumPassbb / sumPasscc
 
                 tqqpassbb.setParamEffect(tqqeffSF, 1 * tqqeffSF)
@@ -603,49 +686,54 @@ def rhalphabet(args):
                 tqqpasscc.setParamEffect(tqqnormSF, 1 * tqqnormSF)
                 tqqfail.setParamEffect(tqqnormSF, 1 * tqqnormSF)
 
-    muonCR_model = rl.Model('muonCR_'+year)
+    muonCR_model = rl.Model("muonCR_" + year)
     if do_muon_CR:
         templates = {}
-        samps = ['QCD','ttbar','singlet','Wjets','Zjetsc','Zjetslight','Zjetsbb']
-        for region in ['pass_bb_', 'pass_cc_', 'fail_']:
+        samps = ["QCD", "ttbar", "singlet", "Wjets", "Zjetsc", "Zjetslight", "Zjetsbb"]
+        for region in ["pass_bb_", "pass_cc_", "fail_"]:
 
-            ch_name = 'muonCR%s%s' % (region.replace("_", ""), year)
+            ch_name = f"muonCR_{region.replace('_', '')}_{year}"
 
             ch = rl.Channel(ch_name)
             muonCR_model.addChannel(ch)
             for sName in samps:
-                templates[sName] = one_bin(infile_path, sName, region, 1, 'mucr_', syst='nominal')
+                templates[sName] = one_bin(infile_path, sName, region, 1, "mucr_", syst="nominal")
                 nominal = templates[sName][0]
 
                 if nominal < eps:
-                    print("Sample {} is too small, skipping".format(sName))
+                    print(f"Sample {sName} is too small, skipping")
                     continue
 
                 stype = rl.Sample.BACKGROUND
-                sample = rl.TemplateSample(ch.name + '_' + sName, stype, templates[sName])
+                sample = rl.TemplateSample(ch.name + "_" + sName, stype, templates[sName])
 
-                sample.setParamEffect(sys_lumi_uncor, lumi_err[year[:4]] ** (LUMI[year[:4]] / LUMI["2022-2024"]))
+                sample.setParamEffect(
+                    sys_lumi_uncor, lumi_err[year[:4]] ** (LUMI[year[:4]] / LUMI["2022-2024"])
+                )
                 if do_systematics:
 
-                    sample.autoMCStats(lnN=True) 
+                    sample.autoMCStats(lnN=True)
 
                 ch.addSample(sample)
-                
-            data_obs = one_bin(infile_path, 'Muondata', region, 1, 'mucr_', syst='nominal')
+
+            data_obs = one_bin(infile_path, "Muondata", region, 1, "mucr_", syst="nominal")
             ch.setObservation(data_obs, read_sumw2=True)
 
-        tqqpassbb = muonCR_model['muonCRpassbb'+year+'_ttbar']
-        tqqpasscc = muonCR_model['muonCRpasscc'+year+'_ttbar']
-        tqqfail = muonCR_model['muonCRfail'+year+'_ttbar']
+        tqqpassbb = muonCR_model["muonCRpassbb" + year + "_ttbar"]
+        tqqpasscc = muonCR_model["muonCRpasscc" + year + "_ttbar"]
+        tqqfail = muonCR_model["muonCRfail" + year + "_ttbar"]
 
-        sumPass = tqqpassbb.getExpectation(nominal=True).sum() + tqqpasscc.getExpectation(nominal=True).sum()
+        sumPass = (
+            tqqpassbb.getExpectation(nominal=True).sum()
+            + tqqpasscc.getExpectation(nominal=True).sum()
+        )
         sumPassbb = tqqpassbb.getExpectation(nominal=True).sum()
         sumPasscc = tqqpasscc.getExpectation(nominal=True).sum()
         sumFail = tqqfail.getExpectation(nominal=True).sum()
 
-        stqqpassbb = muonCR_model['muonCRpassbb'+year+'_singlet']
-        stqqpasscc = muonCR_model['muonCRpasscc'+year+'_singlet']
-        stqqfail = muonCR_model['muonCRfail'+year+'_singlet']
+        stqqpassbb = muonCR_model["muonCRpassbb" + year + "_singlet"]
+        stqqpasscc = muonCR_model["muonCRpasscc" + year + "_singlet"]
+        stqqfail = muonCR_model["muonCRfail" + year + "_singlet"]
 
         sumPass += stqqpassbb.getExpectation(nominal=True).sum()
         sumPass += stqqpasscc.getExpectation(nominal=True).sum()
@@ -654,7 +742,7 @@ def rhalphabet(args):
         sumPasscc += stqqpasscc.getExpectation(nominal=True).sum()
         sumFail += stqqfail.getExpectation(nominal=True).sum()
 
-        tqqPF =  sumPass / sumFail
+        tqqPF = sumPass / sumFail
         tqqBC = sumPassbb / sumPasscc
 
         tqqpassbb.setParamEffect(tqqeffSF, 1 * tqqeffSF)

--- a/fitting/make_hists.py
+++ b/fitting/make_hists.py
@@ -101,7 +101,14 @@ def fill_binned_histogram(
         else:
             Txcc = data["FatJet0_ParTPXccVsQCD"]
             Txbb = data["FatJet0_ParTPXbbVsQCD"]
-            Txbbxcc = data["FatJet0_ParTPXbbXcc"]
+            if setup.get("use_modified_disc", False):
+                # Modified discriminant: (Xbb+Xcc) / (Xbb+Xcc+QCD+Xcs)
+                # Penalises W→cs events in the denominator
+                _num = data["FatJet0_ParTPXbb"] + data["FatJet0_ParTPXcc"]
+                _den = (_num + data["FatJet0_ParTPQCD"] + data["FatJet0_ParTPXcs"]).replace(0, np.nan)
+                Txbbxcc = (_num / _den).fillna(0.0)
+            else:
+                Txbbxcc = data["FatJet0_ParTPXbbXcc"]
             selection_dict = {
                 "pass_bb": pre_selection & (Txbbxcc > working_point) & (Txbb > Txcc),
                 "pass_cc": pre_selection & (Txbbxcc > working_point) & (Txcc > Txbb),
@@ -231,6 +238,14 @@ def main(args):
             "FatJet0_ParTPXbbXcc",
             "GenFlavor",
         ]
+        if setup.get("use_modified_disc", False):
+            # Raw ParT probabilities needed to compute modified discriminant on-the-fly
+            cols += [
+                "FatJet0_ParTPXbb",
+                "FatJet0_ParTPXcc",
+                "FatJet0_ParTPQCD",
+                "FatJet0_ParTPXcs",
+            ]
         if data_map_key == "EGammadata":
             cols += [
                 "Photon0_pt",
@@ -337,7 +352,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Unified Histogram Maker for Signal and CR")
     parser.add_argument("--year", required=True, choices=["2022", "2022EE", "2023", "2023BPix", "2024"])
-    parser.add_argument("--tag", required=True, help="Tag for the skims directory (e.g., 26Feb03)")
+    parser.add_argument("--tag", default=None, help="Tag for the skims directory (e.g., 26Feb03). Required if --data-dir is not provided.")
     parser.add_argument("--setup", required=True, help="Path to setup.json file")
     parser.add_argument("--outdir", default="results", help="Directory to save ROOT files")
     parser.add_argument("--save-root", action="store_true", help="Actually write the ROOT file")
@@ -349,6 +364,9 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    if args.tag is None and args.data_dir is None:
+        parser.error("--tag is required when --data-dir is not provided.")
 
     # Ensure outdir exists before starting
     Path(args.outdir).mkdir(parents=True, exist_ok=True)

--- a/fitting/plot_jmsr.py
+++ b/fitting/plot_jmsr.py
@@ -1,0 +1,236 @@
+"""
+plot_jmsr.py
+------------
+Read a Combine RooWorkspace and plot nominal, JMS (scaleUp/Down) and
+JMR (smearUp/Down) shapes for every channel and process that has them.
+
+Usage
+-----
+    python plot_jmsr.py \\
+        --file results/.../zgcrModel_2022EE.root \\
+        --wsname zgcrModel_2022EE \\
+        --outdir plots/jmsr
+
+    # Restrict to one channel or process
+    python plot_jmsr.py --file ... --channel passbb --process zgammabb
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import mplhep as hep
+import numpy as np
+import ROOT
+from card_utils import safe_ratio
+
+ROOT.gROOT.SetBatch(True)
+plt.style.use(hep.style.CMS)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Maps a systematic label to the (up, down) suffix as written in the workspace.
+# The {year} placeholder is filled at runtime.
+VARIATION_PAIRS: dict[str, tuple[str, str]] = {
+    "JMS": ("CMS_jms_{year}Up", "CMS_jms_{year}Down"),
+    "JMR": ("CMS_jmr_{year}Up", "CMS_jmr_{year}Down"),
+}
+
+COL_NOM = "black"
+COL_UP = "blue"
+COL_DN = "violet"
+
+SKIP_KEYS = {"observation"}
+
+
+# ---------------------------------------------------------------------------
+# Workspace reading
+# ---------------------------------------------------------------------------
+
+
+def _datahist_to_arrays(dh) -> tuple[np.ndarray, np.ndarray]:
+    """Convert a RooDataHist to (values, edges) using its first observable."""
+    obs_var = next(iter(dh.get()))
+    h = dh.createHistogram(dh.GetName() + "__tmp", obs_var)
+    n = h.GetNbinsX()
+    edges = np.array([h.GetBinLowEdge(i) for i in range(1, n + 2)])
+    values = np.array([h.GetBinContent(i) for i in range(1, n + 1)])
+    return values, edges
+
+
+def _parse_name(name: str, all_suffixes: set[str]) -> tuple[str, str, str]:
+    """Split a RooDataHist name into (channel, process, variation).
+
+    Names follow the pattern:
+        {channel}_{process}[_{variation}]
+
+    Tries longest suffixes first to avoid partial matches.
+    """
+    for suffix in sorted(all_suffixes, key=len, reverse=True):
+        if name.endswith(f"_{suffix}"):
+            rest = name[: -len(f"_{suffix}")]
+            channel, _, process = rest.rpartition("_")
+            return channel, process, suffix
+
+    # No variation suffix — nominal.
+    channel, _, process = name.rpartition("_")
+    return channel, process, ""
+
+
+def collect_templates(
+    ws_path: str,
+    ws_name: str,
+    year: str,
+    channel_filter: str | None,
+    process_filter: str | None,
+) -> dict[str, dict[str, dict[str, tuple]]]:
+    """Read all RooDataHist objects from the workspace.
+
+    Returns
+    -------
+    dict  channel -> process -> {nominal | <variation>} -> (values, edges)
+    """
+    all_suffixes = {
+        suf.format(year=year) for _, (up, dn) in VARIATION_PAIRS.items() for suf in (up, dn)
+    }
+
+    root_file = ROOT.TFile.Open(ws_path)
+    ws = root_file.Get(ws_name)
+
+    templates: dict = defaultdict(lambda: defaultdict(dict))
+
+    for dh in ws.allData():
+        name = dh.GetName()
+
+        if any(skip in name for skip in SKIP_KEYS):
+            continue
+
+        channel, process, variation = _parse_name(name, all_suffixes)
+        label = variation if variation else "nominal"
+
+        if channel_filter and channel_filter not in channel:
+            continue
+        if process_filter and process_filter not in process:
+            continue
+
+        try:
+            templates[channel][process][label] = _datahist_to_arrays(dh)
+        except Exception as exc:
+            print(f"  Warning: could not read {name!r}: {exc}")
+
+    root_file.Close()
+    return templates
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+def plot_variation(
+    channel: str,
+    process: str,
+    syst_name: str,
+    up_suffix: str,
+    dn_suffix: str,
+    hists: dict[str, tuple],
+    outdir: Path,
+) -> None:
+    if "nominal" not in hists:
+        return
+    if up_suffix not in hists or dn_suffix not in hists:
+        return
+
+    nom_vals, edges = hists["nominal"]
+    up_vals, _ = hists[up_suffix]
+    dn_vals, _ = hists[dn_suffix]
+
+    fig, (ax, rax) = plt.subplots(
+        2,
+        1,
+        figsize=(8, 7),
+        gridspec_kw={"height_ratios": [3, 1], "hspace": 0},
+        sharex=True,
+    )
+
+    hep.histplot((nom_vals, edges), ax=ax, color=COL_NOM, ls="-", linewidth=2, label="Nominal")
+    hep.histplot(
+        (up_vals, edges), ax=ax, color=COL_UP, ls="--", linewidth=1.5, label=f"{syst_name} up"
+    )
+    hep.histplot(
+        (dn_vals, edges), ax=ax, color=COL_DN, ls="--", linewidth=1.5, label=f"{syst_name} down"
+    )
+    ax.set_ylabel("Events / bin")
+    ax.set_ylim(bottom=0)
+    ax.legend(fontsize=11)
+    ax.set_title(f"{channel}  |  {process}  |  {syst_name}", fontsize=10)
+
+    hep.histplot(
+        (safe_ratio(up_vals, nom_vals), edges), ax=rax, color=COL_UP, ls="--", linewidth=1.5
+    )
+    hep.histplot(
+        (safe_ratio(dn_vals, nom_vals), edges), ax=rax, color=COL_DN, ls="--", linewidth=1.5
+    )
+    rax.axhline(1.0, color=COL_NOM, ls=":", linewidth=1)
+    rax.set_ylabel("Var / Nom")
+    rax.set_xlabel("Jet mass (GeV)")
+    rax.set_ylim(0.5, 1.5)
+    rax.grid(axis="y", linestyle=":", alpha=0.5)
+
+    fname = outdir / f"{channel}_{process}_{syst_name}.png"
+    fig.savefig(fname, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+    print(f"  Saved: {fname}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plot JMS/JMR shape variations from a Combine RooWorkspace."
+    )
+    parser.add_argument(
+        "--file",
+        "-f",
+        default="results/26Apr27/2022EE/datacards/zgcrModel_2022EE/zgcrModel_2022EE.root",
+    )
+    parser.add_argument(
+        "--wsname",
+        "-w",
+        default=None,
+        help="RooWorkspace name inside the file (default: inferred from filename).",
+    )
+    parser.add_argument("--year", default="2022EE")
+    parser.add_argument("--outdir", "-o", default="plots/jmsr")
+    parser.add_argument("--channel", "-c", default=None)
+    parser.add_argument("--process", "-p", default=None)
+    args = parser.parse_args()
+
+    ws_name = args.wsname or Path(args.file).stem
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Opening: {args.file}  (workspace: {ws_name}, year: {args.year})")
+    templates = collect_templates(args.file, ws_name, args.year, args.channel, args.process)
+
+    if not templates:
+        print("No matching templates found. Check --channel / --process / --year.")
+        return
+
+    n_plots = 0
+    for channel, processes in sorted(templates.items()):
+        for process, hists in sorted(processes.items()):
+            for syst_name, (up_tmpl, dn_tmpl) in VARIATION_PAIRS.items():
+                up_suf = up_tmpl.format(year=args.year)
+                dn_suf = dn_tmpl.format(year=args.year)
+                if up_suf in hists or dn_suf in hists:
+                    plot_variation(channel, process, syst_name, up_suf, dn_suf, hists, outdir)
+                    n_plots += 1
+
+    print(f"\nDone — {n_plots} plot(s) written to {outdir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/fitting/plot_jmsr_postfit.py
+++ b/fitting/plot_jmsr_postfit.py
@@ -1,0 +1,390 @@
+"""
+plot_jmsr_postfit.py
+--------------------
+Read fitDiagnosticsTest.root and the initial templates ROOT file, extract the
+fitted JMS/JMR nuisance parameter values, apply the corresponding affine morph
+to the prefit templates, and overlay prefit / postfit / morphed shapes.
+
+The morphing reproduces what Combine did internally:
+    shift = theta_jms * jmsr_scale      (JMS: shifts mass axis)
+    scale = 1 + theta_jmr * jmsr_smear  (JMR: widens/narrows distribution)
+
+Usage, e.g.
+-----
+    python plot_jmsr_postfit.py \\
+        --fitfile  results/26Apr27/2022EE/datacards/zgcrModel_2022EE/fitDiagnosticsTest.root \\
+        --wsfile   results/26Apr27/2022EE/datacards/zgcrModel_2022EE/zgcrModel_2022EE.root \\
+        --wsname   zgcrModel_2022EE \\
+        --year     2022EE \\
+        -j setup_zgcr.json \\
+        --outdir   plots/jmsr_postfit
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import mplhep as hep
+import numpy as np
+import ROOT
+import uproot
+from scalesmear import MorphHistW2
+
+ROOT.gROOT.SetBatch(True)
+plt.style.use(hep.style.CMS)
+
+COL_PREFIT = "blue"
+COL_POSTFIT = "red"
+COL_MORPHED = "black"
+COL_BAND = "0.75"  # grey
+
+# ---------------------------------------------------------------------------
+# Reading helpers
+# ---------------------------------------------------------------------------
+
+
+def read_nuisance(fit_result, name: str) -> tuple[float, float]:
+    """Return (value, error) for a named floating parameter in a RooFitResult."""
+    par = fit_result.floatParsFinal().find(name)
+    if par is None:
+        raise KeyError(f"Parameter {name!r} not found in fit result.")
+    return par.getVal(), par.getError()
+
+
+def datahist_to_arrays(dh) -> tuple[np.ndarray, np.ndarray]:
+    """Convert a RooDataHist to (values, edges)."""
+    obs_var = next(iter(dh.get()))
+    h = dh.createHistogram(dh.GetName() + "__tmp", obs_var)
+    n = h.GetNbinsX()
+    edges = np.array([h.GetBinLowEdge(i) for i in range(1, n + 2)])
+    values = np.array([h.GetBinContent(i) for i in range(1, n + 1)])
+    return values, edges
+
+
+def read_workspace_templates(
+    ws_path: str,
+    ws_name: str,
+) -> dict[str, dict[str, tuple[np.ndarray, np.ndarray]]]:
+    """Read all nominal RooDataHist templates from the workspace.
+
+    Returns
+    -------
+    dict  channel -> process -> (values, edges)
+    """
+    root_file = ROOT.TFile.Open(ws_path)
+    ws = root_file.Get(ws_name)
+
+    templates: dict = {}
+    for dh in ws.allData():
+        name = dh.GetName()
+        # Skip variation and observation entries — keep only nominals.
+        if any(tag in name for tag in ("Up", "Down", "observation")):
+            continue
+        # Name pattern: {channel}_{process}
+        channel, _, process = name.rpartition("_")
+        templates.setdefault(channel, {})[process] = datahist_to_arrays(dh)
+
+    root_file.Close()
+    return templates
+
+
+def convTH1(h) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Convert an uproot TH1 to (values, edges, variances), density-corrected."""
+    vals = h.values()
+    edges = h.axes[0].edges()
+    variances = h.variances()
+    widths = np.diff(edges)
+    return vals * widths, edges, variances * widths
+
+
+# ---------------------------------------------------------------------------
+# Morphing
+# ---------------------------------------------------------------------------
+
+
+def apply_morph(
+    nominal: tuple[np.ndarray, np.ndarray],
+    theta_jms: float,
+    theta_jmr: float,
+    jmsr_scale: float,
+    jmsr_smear: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply the fitted JMS+JMR morph to a nominal (values, edges) template.
+
+    The combined transformation maps:
+        mass_axis -> (mass_axis - shift) / scale
+    where
+        shift = theta_jms * jmsr_scale
+        scale = 1 + theta_jmr * jmsr_smear
+    """
+    sumw, edges = nominal
+    # MorphHistW2 needs a sumw2 — use sumw as a placeholder (shape only matters here)
+    morph = MorphHistW2((sumw, edges, sumw.copy()))
+
+    shift = theta_jms * jmsr_scale
+    scale = 1.0 + theta_jmr * jmsr_smear
+
+    morphed_sumw, morphed_edges, _ = morph.get(shift=shift, scale=scale)
+    return morphed_sumw, morphed_edges
+
+
+def read_signal_strengths(fit_result) -> dict[str, float]:
+    """Return {par_name: value} for all 'r_*' parameters in the fit."""
+    pars = fit_result.floatParsFinal()
+    return {p.GetName(): p.getVal() for p in pars if p.GetName().startswith("r_")}
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def plot_channel_process(
+    channel: str,
+    process: str,
+    prefit_templ: tuple,
+    postfit_templ: tuple | None,
+    morphed_templ: tuple,
+    morphed_up: tuple,
+    morphed_dn: tuple,
+    theta_jms: float,
+    theta_jmr: float,
+    outdir: Path,
+) -> None:
+    fig, (ax, rax) = plt.subplots(
+        2,
+        1,
+        figsize=(8, 7),
+        gridspec_kw={"height_ratios": [3, 1], "hspace": 0},
+        sharex=True,
+    )
+
+    prefit_vals, edges = prefit_templ[0], prefit_templ[1]
+    morphed_vals, _ = morphed_templ
+    up_vals, _ = morphed_up
+    dn_vals, _ = morphed_dn
+
+    # --- upper panel ---
+    hep.histplot(
+        (prefit_vals, edges),
+        ax=ax,
+        color=COL_PREFIT,
+        ls="--",
+        linewidth=1.5,
+        label="Prefit (nominal)",
+    )
+    hep.histplot(
+        (morphed_vals, edges),
+        ax=ax,
+        color=COL_MORPHED,
+        ls="-",
+        linewidth=2,
+        label=(f"Morphed (JMS $\\theta$={theta_jms:.2f}, " f"JMR $\\theta$={theta_jmr:.2f})"),
+    )
+    # 1-sigma band from ±1sigma on each nuisance independently
+    band_lo = np.minimum(up_vals, dn_vals)
+    band_hi = np.maximum(up_vals, dn_vals)
+    ax.fill_between(
+        edges[:-1] + np.diff(edges) / 2,
+        band_lo,
+        band_hi,
+        step="mid",
+        alpha=0.25,
+        color=COL_MORPHED,
+        label=r"Morph ±1$\sigma$ band",
+    )
+    if postfit_templ is not None:
+        postfit_vals, _ = postfit_templ[0], postfit_templ[1]
+        hep.histplot(
+            (postfit_vals, edges),
+            ax=ax,
+            color=COL_POSTFIT,
+            ls=":",
+            linewidth=1.5,
+            label="Postfit (Combine)",
+        )
+
+    ax.set_ylabel("Events / bin")
+    ax.set_ylim(bottom=0)
+    ax.legend(fontsize=9, loc="upper right")
+    ax.set_title(f"{channel}  |  {process}", fontsize=10)
+
+    # --- ratio panel (morphed / prefit) ---
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(prefit_vals > 0, morphed_vals / prefit_vals, 1.0)
+        ratio_up = np.where(prefit_vals > 0, up_vals / prefit_vals, 1.0)
+        ratio_dn = np.where(prefit_vals > 0, dn_vals / prefit_vals, 1.0)
+
+    hep.histplot((ratio, edges), ax=rax, color=COL_MORPHED, ls="-", linewidth=2)
+    rax.fill_between(
+        edges[:-1] + np.diff(edges) / 2,
+        np.minimum(ratio_up, ratio_dn),
+        np.maximum(ratio_up, ratio_dn),
+        step="mid",
+        alpha=0.25,
+        color=COL_MORPHED,
+    )
+    rax.axhline(1.0, color="black", ls=":", linewidth=1)
+    rax.set_ylabel("Morphed / Prefit")
+    rax.set_xlabel("Jet mass (GeV)")
+    rax.set_ylim(0.5, 1.5)
+    rax.grid(axis="y", linestyle=":", alpha=0.5)
+
+    fname = outdir / f"{channel}_{process}_postfit_morph.png"
+    fig.savefig(fname, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+    print(f"  Saved: {fname}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plot postfit JMS/JMR morphed templates from fitDiagnostics."
+    )
+    parser.add_argument("--fitfile", "-f", required=True, help="Path to fitDiagnosticsTest.root.")
+    parser.add_argument(
+        "--wsfile",
+        "-w",
+        required=True,
+        help="Path to the Combine RooWorkspace ROOT file e.g. zgcrModel_2022EE.root",
+    )
+    parser.add_argument(
+        "--wsname", default=None, help="RooWorkspace name (default: inferred from filename)."
+    )
+    parser.add_argument("--year", required=True)
+    parser.add_argument(
+        "--config",
+        "-j",
+        required=True,
+        help="Path to analysis JSON config (e.g. setup_zgcr.json). ",
+    )
+    parser.add_argument("--outdir", "-o", default="plots/jmsr_postfit")
+    parser.add_argument(
+        "--channel", "-c", default=None, help="Filter: only plot channels containing this string."
+    )
+    parser.add_argument(
+        "--process", "-p", default=None, help="Filter: only plot processes containing this string."
+    )
+    args = parser.parse_args()
+
+    with Path(args.config).open() as f:
+        config = json.load(f)
+
+    jmsr_processes = config.get("jmsr_processes", [])
+    JMSR_SCALE = config.get("jmsr_scale", 1.0)
+    JMSR_SMEAR = config.get("jmsr_smear", 0.1)
+
+    sample_dict = config["process_groups"]
+    signal_processes = {name for name, info in sample_dict.items() if info.get("is_signal", False)}
+
+    # Resolve which processes are affected by JMSR.
+    # --process overrides the config if both are given.
+    if args.process is not None:
+        jmsr_processes = [args.process]
+        print(f"JMSR processes (from --process): {jmsr_processes}")
+
+    ws_name = args.wsname or Path(args.wsfile).stem
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # --- 1. Read fitted nuisance values ---
+    fit_file = ROOT.TFile.Open(args.fitfile)
+    fit_result = fit_file.Get("fit_s")
+
+    jms_name = f"CMS_jms_{args.year}"
+    jmr_name = f"CMS_jmr_{args.year}"
+    theta_jms, jms_err = read_nuisance(fit_result, jms_name)
+    theta_jmr, jmr_err = read_nuisance(fit_result, jmr_name)
+    print("\nFitted nuisances:")
+    print(f"  {jms_name}: {theta_jms:.4f} +/- {jms_err:.4f}")
+    print(f"  {jmr_name}: {theta_jmr:.4f} +/- {jmr_err:.4f}")
+
+    # Physical shifts corresponding to the fit values
+    fitted_shift = theta_jms * JMSR_SCALE
+    fitted_scale = 1.0 + theta_jmr * JMSR_SMEAR
+    print("\nPhysical morph:")
+    print(f"  JMS shift = {theta_jms:.4f} x {JMSR_SCALE} GeV = {fitted_shift:.4f} GeV")
+    print(f"  JMR scale = 1 + {theta_jmr:.4f} x {JMSR_SMEAR} = {fitted_scale:.4f}")
+
+    # Signal strengths
+    signal_strengths = read_signal_strengths(fit_result)
+
+    # Map channel to signal strength
+    # r_bb applies to passbb channels, r_cc to passcc
+    def get_signal_strength(channel: str) -> float:
+        for r_name, r_val in signal_strengths.items():
+            region = r_name.replace("r_", "")  # "bb", "cc"
+            if region in channel:
+                return r_val
+        return 1.0
+
+    # --- 2. Read prefit templates from workspace ---
+    print(f"\nReading templates from: {args.wsfile}")
+    templates = read_workspace_templates(args.wsfile, ws_name)
+
+    # --- 3. Read postfit shapes from fitDiagnostics (for overlay) ---
+    fd = uproot.open(args.fitfile)
+    postfit_shapes = {}
+    for raw_key in fd["shapes_fit_s"]:
+        key = raw_key.replace(";1", "")
+        if "/" not in key:
+            continue
+        region, proc = key.split("/", 1)
+        with contextlib.suppress(Exception):
+            postfit_shapes.setdefault(region, {})[proc] = convTH1(fd[f"shapes_fit_s/{key}"])
+
+    fit_file.Close()
+
+    # --- 4. Apply morph and plot ---
+    n_plots = 0
+    for channel, processes in sorted(templates.items()):
+        if args.channel and args.channel not in channel:
+            continue
+        for process, (sumw, edges) in sorted(processes.items()):
+            # Only plot processes that are listed as JMSR-affected in the config.
+            if not any(p in process for p in jmsr_processes):
+                continue
+
+            if args.process and args.process not in process:
+                continue
+            if sumw.sum() == 0:
+                continue
+
+            # multiply process by signal strength
+            is_signal = process in signal_processes
+            r_val = get_signal_strength(channel) if is_signal else 1.0
+            print(f"Multiplying {process} by {r_val}")
+            nominal = (sumw * r_val, edges)
+
+            morphed = apply_morph(nominal, theta_jms, theta_jmr, JMSR_SCALE, JMSR_SMEAR)
+            morph_up = apply_morph(
+                nominal, theta_jms + jms_err, theta_jmr + jmr_err, JMSR_SCALE, JMSR_SMEAR
+            )
+            morph_dn = apply_morph(
+                nominal, theta_jms - jms_err, theta_jmr - jmr_err, JMSR_SCALE, JMSR_SMEAR
+            )
+
+            postfit = postfit_shapes.get(channel, {}).get(process)
+
+            plot_channel_process(
+                channel=channel,
+                process=process,
+                prefit_templ=nominal,
+                postfit_templ=postfit,
+                morphed_templ=morphed,
+                morphed_up=morph_up,
+                morphed_dn=morph_dn,
+                theta_jms=theta_jms,
+                theta_jmr=theta_jmr,
+                outdir=outdir,
+            )
+            n_plots += 1
+
+    print(f"\nDone — {n_plots} plot(s) written to {outdir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/fitting/scalesmear.py
+++ b/fitting/scalesmear.py
@@ -1,0 +1,282 @@
+"""
+scalesmear.py
+-------------
+Utilities for applying affine (shift + scale) morphing to 1D histograms,
+primarily used to model jet mass scale (JMS) and jet mass resolution (JMR)
+systematic variations in CMS analyses.
+
+Classes
+-------
+AffineMorphTemplate
+    Morphs a histogram by shifting and/or scaling its mass axis.
+MorphHistW2
+    Wraps AffineMorphTemplate to propagate sumw2 (bin variance) alongside
+    bin contents through the same morphing.
+
+Functions
+---------
+poisson_interval  : Garwood frequentist coverage interval for weighted histograms.
+export1d          : Convert a (sumw, edges[, sumw2]) tuple to a boost-histogram.
+mdev              : Compute the mean and standard deviation of a histogram.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import boost_histogram as bh
+import numpy as np
+import scipy.stats
+from scipy.interpolate import interp1d
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# One-sigma central coverage for a normal distribution (~68.27%)
+_COVERAGE_1SD: float = scipy.stats.norm.cdf(1) - scipy.stats.norm.cdf(-1)
+
+# Histogram tuple type alias for readability: (sumw, edges) or (sumw, edges, sumw2)
+HistTuple = tuple[np.ndarray, np.ndarray]
+HistTupleW2 = tuple[np.ndarray, np.ndarray, np.ndarray]
+
+
+def poisson_interval(
+    sumw: np.ndarray,
+    sumw2: np.ndarray,
+    coverage: float = _COVERAGE_1SD,
+) -> np.ndarray:
+    """Frequentist (Garwood) coverage interval for Poisson-distributed observations.
+
+    For weighted data the observed count is approximated as ``sumw**2 / sumw2``,
+    which rescales the unweighted Poisson interval by the mean weight per bin.
+    Empty bins borrow the scale factor from the nearest non-empty neighbour.
+    If *all* bins are empty a ``RuntimeWarning`` is issued and the interval
+    collapses to ``sumw``.
+
+    Parameters
+    ----------
+    sumw:
+        Array of summed weights (one entry per bin).
+    sumw2:
+        Array of summed squared weights (one entry per bin).
+    coverage:
+        Central coverage fraction. Defaults to the 1-sigma normal interval
+        (~68.27%).
+
+    Returns
+    -------
+    np.ndarray, shape (2, nbins)
+        Row 0 is the lower bound; row 1 is the upper bound.
+
+    References
+    ----------
+    * Garwood (1936) via https://www.ine.pt/revstat/pdf/rs120203.pdf  # codespell:ignore ine
+    * http://ms.mcmaster.ca/peter/s743/poissonalpha.html
+    * Weighted-data treatment: https://arxiv.org/pdf/1309.1287.pdf
+    * Originally adapted from Coffea.
+    """
+    scale = np.empty_like(sumw)
+    filled = sumw != 0
+    scale[filled] = sumw2[filled] / sumw[filled]
+
+    empty = ~filled
+    if empty.any():
+        available = np.nonzero(sumw)
+        if len(available[0]) == 0:
+            warnings.warn(
+                "All sumw are zero! Cannot compute meaningful error bars.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return np.vstack([sumw, sumw])
+
+        missing = np.where(empty)
+        # For each empty bin find the nearest non-empty bin (Euclidean distance).
+        nearest_idx = np.sum(
+            [np.subtract.outer(d, d0) ** 2 for d, d0 in zip(available, missing)]
+        ).argmin(axis=0)
+        nearest = tuple(dim[nearest_idx] for dim in available)
+        scale[missing] = scale[nearest]
+
+    counts = sumw / scale
+    lo = scale * scipy.stats.chi2.ppf((1 - coverage) / 2, 2 * counts) / 2.0
+    hi = scale * scipy.stats.chi2.ppf((1 + coverage) / 2, 2 * (counts + 1)) / 2.0
+
+    interval = np.array([lo, hi])
+    interval = np.nan_to_num(interval, nan=0.0)
+    return interval
+
+
+# ---------------------------------------------------------------------------
+# Morphing classes
+# ---------------------------------------------------------------------------
+
+
+class AffineMorphTemplate:
+    """Apply an affine transformation to the mass axis of a 1D histogram.
+
+    The transformation maps each bin edge ``x`` to ``(x - shift) / scale``,
+    which is equivalent to shifting the *distribution* by ``+shift`` and
+    widening it by ``scale``. The total normalisation is preserved.
+
+    Parameters
+    ----------
+    hist:
+        A ``(sumw, edges)`` tuple where *sumw* has length ``len(edges) - 1``.
+    """
+
+    def __init__(self, hist: HistTuple) -> None:
+        self.sumw, self.edges = hist
+        self.centers: np.ndarray = self.edges[:-1] + np.diff(self.edges) / 2.0
+
+        self.norm: float = float(self.sumw.sum())
+        self.mean: float = float((self.sumw * self.centers).sum() / self.norm)
+
+        # Build a CDF interpolant over bin edges for fast morphing.
+        self._cdf = interp1d(
+            x=self.edges,
+            y=np.r_[0.0, np.cumsum(self.sumw / self.norm)],
+            kind="linear",
+            assume_sorted=True,
+            bounds_error=False,
+            fill_value=(0.0, 1.0),
+        )
+
+    def get(self, shift: float = 0.0, scale: float = 1.0) -> HistTuple:
+        """Return a morphed copy of the histogram.
+
+        The physical interpretation is:
+        * ``shift > 0``: distribution moves to higher mass.
+        * ``scale > 1``: distribution becomes wider (poorer resolution).
+
+        When ``scale != 1`` the shift is adjusted so that the *mean* of the
+        distribution is preserved under pure scaling (i.e. the scale pivots
+        around the mean).
+
+        Parameters
+        ----------
+        shift:
+            Additive offset applied to the mass axis (same units as the axis).
+        scale:
+            Multiplicative factor applied to the mass axis.
+
+        Returns
+        -------
+        tuple[np.ndarray, np.ndarray]
+            ``(morphed_sumw, original_edges)`` — edges are unchanged.
+        """
+        if not np.isclose(scale, 1.0):
+            # Pivot the scale around the distribution mean so that a pure
+            # rescaling does not shift the peak position.
+            shift += self.mean * (1.0 - scale)
+
+        morphed_edges = (self.edges - shift) / scale
+        morphed_sumw = np.diff(self._cdf(morphed_edges)) * self.norm
+        return morphed_sumw, self.edges
+
+    def rescale(self, factor: float) -> None:
+        """Multiply the total normalisation by *factor* in-place."""
+        self.norm *= factor
+
+
+class MorphHistW2:
+    """Affine morphing that propagates bin variances (sumw2) alongside bin contents.
+
+    Both the bin-content histogram and the variance histogram are morphed
+    independently using :class:`AffineMorphTemplate`, so the output retains
+    proper statistical uncertainties after morphing.
+
+    Parameters
+    ----------
+    hist:
+        Either an uproot/UHI histogram object (must expose ``.values()``,
+        ``.axes[0].edges()``, and ``.variances()``) or a plain
+        ``(sumw, edges, sumw2)`` tuple.
+    """
+
+    def __init__(self, hist: HistTupleW2) -> None:
+        self._original = hist
+
+        # Accept both UHI histogram objects and raw (sumw, edges, sumw2) tuples.
+        try:
+            sumw = hist.values()
+            edges = hist.axes[0].edges()
+            sumw2 = hist.variances()
+        except AttributeError:
+            sumw, edges, sumw2 = hist
+
+        self._nominal = AffineMorphTemplate((sumw, edges))
+        self._variances = AffineMorphTemplate((sumw2, edges))
+
+    def get(self, shift: float = 0.0, scale: float = 1.0) -> HistTupleW2:
+        """Return morphed ``(sumw, edges, sumw2)`` for the given shift and scale.
+
+        Parameters
+        ----------
+        shift:
+            Additive offset on the mass axis (same units as axis).
+        scale:
+            Multiplicative factor on the mass axis.
+
+        Returns
+        -------
+        tuple[np.ndarray, np.ndarray, np.ndarray]
+            ``(morphed_sumw, edges, morphed_sumw2)``.
+        """
+        morphed_sumw, edges = self._nominal.get(shift, scale)
+        morphed_sumw2, _ = self._variances.get(shift, scale)
+        return morphed_sumw, edges, morphed_sumw2
+
+
+# ---------------------------------------------------------------------------
+# ROOT / boost-histogram I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def export1d(hist: HistTuple | HistTupleW2) -> bh.Histogram:
+    """Convert a histogram tuple to a weighted boost-histogram.
+
+    Parameters
+    ----------
+    hist:
+        Either ``(sumw, edges)`` or ``(sumw, edges, sumw2)``.  When only two
+        elements are provided, ``sumw2`` defaults to ``sumw`` (i.e. unweighted
+        Poisson statistics are assumed).
+
+    Returns
+    -------
+    bh.Histogram
+        A variable-bin weighted histogram compatible with uproot's ``recreate``.
+    """
+    if len(hist) == 3:
+        sumw, edges, sumw2 = hist
+    else:
+        sumw, edges = hist
+        sumw2 = sumw.copy()
+
+    h = bh.Histogram(bh.axis.Variable(edges), storage=bh.storage.Weight())
+    h.view().value = sumw
+    h.view().variance = sumw2
+    return h
+
+
+def mdev(hist: HistTuple) -> np.ndarray:
+    """Return the mean and standard deviation of a 1D histogram.
+
+    Parameters
+    ----------
+    hist:
+        ``(sumw, edges)`` tuple.
+
+    Returns
+    -------
+    np.ndarray, shape (2,)
+        ``[mean, std_dev]``.
+    """
+    sumw, edges = hist
+    total = sumw.sum()
+    centers = edges[:-1] + 0.5 * np.diff(edges)
+    mean = (sumw * centers).sum() / total
+    variance = (sumw * (centers - mean) ** 2).sum() / total
+    return np.array([mean, np.sqrt(variance)])

--- a/fitting/setup_zgcr.json
+++ b/fitting/setup_zgcr.json
@@ -3,17 +3,21 @@
     "qcd_proc": "GJets",
     "pt_min_scale": 250.0,
     "regions_to_fit": ["bb", "cc"],
-    "do_systematics": false,
-    "active_systematics": ["pileup", "JES", "JER"],
+    "use_modified_disc": true,
+    "do_systematics": true,
+    "active_systematics": ["JMSunconstrained", "JMRunconstrained"],
+    "jmsr_scale": 7,
+    "jmsr_smear": 0.5,
+    "jmsr_processes": ["zgammabb", "zgammacc"],
     "rho_scaling_max": -1.0,
     "samples_qq": ["Wjets", "Zjets", "Wgamma", "Zgamma", "TTGamma"],
 
     "observable": {
         "name": "msd",
         "branch_name": "FatJet0_msd",
-        "min": 20,
+        "min": 40,
         "max": 201,
-        "nbins": 23
+        "nbins": 21
     },
 
     "categories": {

--- a/fitting/summarize_jmsr.py
+++ b/fitting/summarize_jmsr.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+summarize_jmsr.py — Tabulate JMS/JMR nuisance fit results.
+
+Reads a CombineTool impacts JSON (preferred — has values + errors + POIs)
+or a fitDiagnostics ROOT file (central values only, no errors).
+
+Writes:
+  - Pretty table to stdout
+  - Markdown table  →  <output>.md
+  - CSV             →  <output>.csv
+
+Usage:
+    # From impacts JSON (recommended — run after combineTool -M Impacts):
+    python summarize_jmsr.py \\
+        --impacts impacts_newdisc_jmsr.json \\
+        --setup   setup_zgcr.json \\
+        --tag     newdisc_jmsr \\
+        --output  jmsr_results_newdisc_jmsr.md
+
+    # From fitDiagnostics only (central values, no uncertainties):
+    python summarize_jmsr.py \\
+        --fitfile fitDiagnostics_Run3_newdisc_jmsr.root \\
+        --setup   setup_zgcr.json \\
+        --tag     newdisc_jmsr
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from datetime import date
+from pathlib import Path
+
+YEARS = ["2022", "2022EE", "2023", "2023BPix", "2024"]
+
+# A nuisance is considered "at boundary" when its central value is within
+# BOUNDARY_TOL of ±1 AND one of its errors is < BOUNDARY_TOL (i.e., it
+# can't move further in that direction).
+BOUNDARY_TOL = 0.05
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+def classify(central: float, err_lo: float, err_hi: float, boundary: float = 1.0) -> str:
+    """Return a human-readable status for a nuisance parameter."""
+    at_bnd = (
+        abs(abs(central) - boundary) < BOUNDARY_TOL
+        and (err_lo < BOUNDARY_TOL or err_hi < BOUNDARY_TOL)
+    )
+    if at_bnd:
+        return "at boundary"
+    avg = 0.5 * (err_lo + err_hi)
+    if avg < 0.3:
+        return "well constrained"
+    if avg < 0.7:
+        return "constrained"
+    return "loosely constrained"
+
+
+def classify_emoji(status: str) -> str:
+    if "boundary" in status:
+        return f"⚠  {status}"
+    if "well" in status:
+        return f"✓  {status}"
+    if "constrained" in status:
+        return f"✓  {status}"
+    return f"~  {status}"
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def load_impacts(path: str) -> tuple[dict, dict]:
+    """Load param_map and poi_map from a combineTool impacts JSON.
+
+    impacts JSON format (from: combineTool.py -M Impacts ... -o out.json):
+        {
+          "POIs":   [{"name": "r_bb", "fit": [central, lo_val, hi_val]}, ...],
+          "params": [{"name": "CMS_jms_2024", "fit": [central, lo_val, hi_val]}, ...]
+        }
+    where lo_val / hi_val are the PARAMETER VALUES at the −1σ / +1σ points,
+    so: err_lo = central − lo_val,  err_hi = hi_val − central.
+    """
+    with open(path) as f:
+        data = json.load(f)
+    param_map = {p["name"]: p for p in data.get("params", [])}
+    poi_map   = {p["name"]: p for p in data.get("POIs",   [])}
+    return param_map, poi_map
+
+
+def load_fitdiag(path: str) -> tuple[dict, dict]:
+    """Load central values only from a fitDiagnostics ROOT TTree (no errors)."""
+    try:
+        import uproot
+    except ImportError:
+        raise SystemExit("uproot is required to read ROOT files.  "
+                         "Install it or use --impacts instead.")
+    with uproot.open(path) as f:
+        tree = f["tree_fit_sb"]
+        arr  = tree.arrays(library="np")
+    param_map = {
+        name: {"fit": [float(arr[name][0])] * 3}   # no errors → fill lo=central=hi
+        for name in tree.keys()
+    }
+    return param_map, {}
+
+
+# ---------------------------------------------------------------------------
+# Row extraction
+# ---------------------------------------------------------------------------
+
+def extract(param_map: dict, poi_map: dict,
+            jmsr_scale: float, jmsr_smear: float) -> tuple[list, dict]:
+    """Build per-year rows and a POI summary dict."""
+
+    rows = []
+    for year in YEARS:
+        row: dict = {"year": year}
+
+        for kind, key in [("JMS", f"CMS_jms_{year}"), ("JMR", f"CMS_jmr_{year}")]:
+            p = param_map.get(key)
+            if p is None:
+                row[kind] = None
+                continue
+
+            fit     = p["fit"]
+            central = fit[0]
+            err_lo  = central - fit[1]   # positive: how far down from central
+            err_hi  = fit[2]  - central  # positive: how far up   from central
+
+            if kind == "JMS":
+                physical_str = f"{central * jmsr_scale:+.1f} GeV"
+            else:
+                physical_str = f"{1.0 + central * jmsr_smear:.2f}×"
+
+            row[kind] = {
+                "central":  central,
+                "err_lo":   err_lo,
+                "err_hi":   err_hi,
+                "physical": physical_str,
+                "status":   classify(central, err_lo, err_hi),
+            }
+
+        rows.append(row)
+
+    pois: dict = {}
+    for poi in ("r_bb", "r_cc"):
+        p = poi_map.get(poi)
+        if p:
+            fit = p["fit"]
+            pois[poi] = {
+                "central": fit[0],
+                "err_lo":  fit[0] - fit[1],
+                "err_hi":  fit[2] - fit[0],
+            }
+
+    return rows, pois
+
+
+# ---------------------------------------------------------------------------
+# Output: terminal
+# ---------------------------------------------------------------------------
+
+def _pull_str(r: dict | None) -> str:
+    if r is None:
+        return "N/A"
+    return f"{r['central']:+.2f} +{r['err_hi']:.2f}/−{r['err_lo']:.2f}"
+
+
+def print_table(rows: list, pois: dict, jmsr_scale: float, jmsr_smear: float, tag: str) -> None:
+    width = 100
+    print()
+    print("=" * width)
+    print(f"  JMSR Fit Results  |  tag: {tag or '(none)'}  |  "
+          f"scale = {jmsr_scale} GeV/σ   smear = {jmsr_smear}/σ")
+    print("=" * width)
+
+    if pois:
+        for poi, v in pois.items():
+            print(f"  {poi} = {v['central']:.3f}  +{v['err_hi']:.3f} / −{v['err_lo']:.3f}")
+        print()
+
+    # Column widths
+    cw = [8, 26, 12, 26, 10, 28]
+    header = ["Year", "JMS (σ)", "JMS shift", "JMR (σ)", "JMR width", "Status (JMS / JMR)"]
+    fmt = "  ".join(f"{{:<{w}}}" for w in cw)
+    sep = "  " + "-" * (sum(cw) + 2 * (len(cw) - 1))
+
+    print(fmt.format(*header))
+    print(sep)
+    for row in rows:
+        jms, jmr = row["JMS"], row["JMR"]
+        jms_status = classify_emoji(jms["status"]) if jms else "—"
+        jmr_status = classify_emoji(jmr["status"]) if jmr else "—"
+        status_combined = f"{jms_status}  /  {jmr_status}"
+        print(fmt.format(
+            row["year"],
+            _pull_str(jms),
+            jms["physical"] if jms else "—",
+            _pull_str(jmr),
+            jmr["physical"] if jmr else "—",
+            status_combined,
+        ))
+    print(sep)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Output: Markdown
+# ---------------------------------------------------------------------------
+
+def write_markdown(rows: list, pois: dict, jmsr_scale: float, jmsr_smear: float,
+                   tag: str, path: Path) -> None:
+    lines = [
+        f"# JMSR Fit Results — `{tag}`",
+        "",
+        f"**Date:** {date.today()}  ",
+        f"**jmsr\\_scale:** {jmsr_scale} GeV/σ &nbsp;&nbsp; "
+        f"**jmsr\\_smear:** {jmsr_smear}/σ",
+        "",
+    ]
+
+    # POI table
+    if pois:
+        lines += [
+            "## Signal strengths",
+            "",
+            "| POI | Best fit | +1σ | −1σ |",
+            "|-----|----------|-----|-----|",
+        ]
+        for poi, v in pois.items():
+            lines.append(
+                f"| `{poi}` | **{v['central']:.3f}** "
+                f"| +{v['err_hi']:.3f} | −{v['err_lo']:.3f} |"
+            )
+        lines.append("")
+
+    # JMS table
+    lines += [
+        "## JMS (Jet Mass Scale)",
+        "",
+        "| Year | θ_JMS | +1σ | −1σ | Shift | Status |",
+        "|------|-------|-----|-----|-------|--------|",
+    ]
+    for row in rows:
+        r = row["JMS"]
+        if r:
+            lines.append(
+                f"| {row['year']} | {r['central']:+.2f} "
+                f"| +{r['err_hi']:.2f} | −{r['err_lo']:.2f} "
+                f"| {r['physical']} | {classify_emoji(r['status'])} |"
+            )
+        else:
+            lines.append(f"| {row['year']} | N/A | — | — | — | — |")
+    lines.append("")
+
+    # JMR table
+    lines += [
+        "## JMR (Jet Mass Resolution)",
+        "",
+        "| Year | θ_JMR | +1σ | −1σ | Width scale | Status |",
+        "|------|-------|-----|-----|-------------|--------|",
+    ]
+    for row in rows:
+        r = row["JMR"]
+        if r:
+            lines.append(
+                f"| {row['year']} | {r['central']:+.2f} "
+                f"| +{r['err_hi']:.2f} | −{r['err_lo']:.2f} "
+                f"| {r['physical']} | {classify_emoji(r['status'])} |"
+            )
+        else:
+            lines.append(f"| {row['year']} | N/A | — | — | — | — |")
+    lines.append("")
+
+    # Legend
+    lines += [
+        "## Legend",
+        "",
+        "- **θ** — dimensionless nuisance parameter (θ = 0: nominal; θ = ±1: ±1σ variation)",
+        f"- **JMS shift** = θ × {jmsr_scale} GeV  (positive = mass peak shifted up)",
+        f"- **JMR width** = 1 + θ × {jmsr_smear}  (> 1: peak broadened; < 1: narrowed)",
+        "- **⚠ at boundary** — statistics-limited; the Z→bb peak has too few events to",
+        "  constrain JMS/JMR. Extending the range will not help.",
+        "- **✓ well constrained** — avg uncertainty < 0.3σ",
+        "- **✓ constrained** — avg uncertainty < 0.7σ",
+        "- **~ loosely constrained** — errors are large; treat with caution",
+    ]
+
+    path.write_text("\n".join(lines) + "\n")
+    print(f"[Saved Markdown → {path}]")
+
+
+# ---------------------------------------------------------------------------
+# Output: CSV
+# ---------------------------------------------------------------------------
+
+def write_csv(rows: list, pois: dict, path: Path) -> None:
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "year",
+            "jms_central", "jms_err_hi", "jms_err_lo", "jms_shift_GeV", "jms_status",
+            "jmr_central", "jmr_err_hi", "jmr_err_lo", "jmr_width_scale", "jmr_status",
+        ])
+        for row in rows:
+            jms, jmr = row["JMS"], row["JMR"]
+            w.writerow([
+                row["year"],
+                f"{jms['central']:.4f}" if jms else "",
+                f"{jms['err_hi']:.4f}"  if jms else "",
+                f"{jms['err_lo']:.4f}"  if jms else "",
+                jms["physical"]          if jms else "",
+                jms["status"]            if jms else "",
+                f"{jmr['central']:.4f}" if jmr else "",
+                f"{jmr['err_hi']:.4f}"  if jmr else "",
+                f"{jmr['err_lo']:.4f}"  if jmr else "",
+                jmr["physical"]          if jmr else "",
+                jmr["status"]            if jmr else "",
+            ])
+
+        # Append POI rows
+        if pois:
+            w.writerow([])
+            w.writerow(["poi", "central", "err_hi", "err_lo"])
+            for poi, v in pois.items():
+                w.writerow([poi, f"{v['central']:.4f}",
+                             f"{v['err_hi']:.4f}", f"{v['err_lo']:.4f}"])
+
+    print(f"[Saved CSV     → {path}]")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(args: argparse.Namespace) -> None:
+    with open(args.setup) as f:
+        setup = json.load(f)
+    jmsr_scale = float(setup.get("jmsr_scale", 3))
+    jmsr_smear = float(setup.get("jmsr_smear", 0.2))
+
+    if args.impacts:
+        param_map, poi_map = load_impacts(args.impacts)
+    else:
+        param_map, poi_map = load_fitdiag(args.fitfile)
+
+    rows, pois = extract(param_map, poi_map, jmsr_scale, jmsr_smear)
+
+    print_table(rows, pois, jmsr_scale, jmsr_smear, args.tag)
+
+    out_md  = Path(args.output)
+    out_csv = out_md.with_suffix(".csv")
+    write_markdown(rows, pois, jmsr_scale, jmsr_smear, args.tag, out_md)
+    write_csv(rows, pois, out_csv)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Tabulate JMS/JMR nuisance results from a Combine fit.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--impacts",
+        metavar="JSON",
+        help="Path to combineTool impacts JSON  (preferred — includes errors)",
+    )
+    src.add_argument(
+        "--fitfile",
+        metavar="ROOT",
+        help="Path to fitDiagnostics ROOT file  (central values only, no errors)",
+    )
+    parser.add_argument(
+        "-j", "--setup",
+        default="setup_zgcr.json",
+        help="Path to setup JSON (reads jmsr_scale, jmsr_smear)",
+    )
+    parser.add_argument(
+        "-o", "--output",
+        default="jmsr_results.md",
+        help="Output Markdown file (a .csv is written alongside it)",
+    )
+    parser.add_argument(
+        "--tag",
+        default="",
+        help="Label for this fit run, e.g. 'newdisc_jmsr'",
+    )
+    main(parser.parse_args())


### PR DESCRIPTION
This PR adds the jet mass scale (JMS) and jet mass resolution (JMR) calibration infrastructure using the Z+γ control region. It supersedes PR#64.
The changes are:
- scalesmear.py: AffineMorphTemplate and MorphHistW2 for JMS/JMR template morphing
- make_datacards.py: Apply JMS/JMR morphing to configure the process with jmsr_processes in the setup JSON, improved - QCD fit diagnostics and added a perturbation on retry
- make_hists.py: Support for modified GloParT discriminant (use_modified_disc) which adds $PX_{cs}$ in the denominator to suppress W→cs contamination in the cc pass region
- setup_zgcr.json: Add zgammacc to jmsr_processes, update mSD range (40–201 GeV), use modified discriminant
- card_utils.py: Add safe_ratio for stable up/down template ratios
- plot_jmsr.py: Prefit JMS/JMR template validation plots
- plot_jmsr_postfit.py: Postfit mSD distributions per era
- summarize_jmsr.py: Tabulate JMS/JMR fit results from fitDiagnostics or impacts JSON.